### PR TITLE
null is valid json, return undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function tryToParseJson(string) {
     result = JSON.parse(string);
   } catch (error) {
     // oh error? well just return null, no biggie
-    result = null;
+    result = undefined;
   }
 
   return result;


### PR DESCRIPTION
`JSON.parse("null") === null`

Since null is valid we return `undefined` instead, this means you know that it was invalid if it returns `undefined`
